### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/src/runtime/vue/vue.ts
+++ b/src/runtime/vue/vue.ts
@@ -364,7 +364,7 @@ function isLoadTimer() {
   })
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $chatwoot: OptionPlugin
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->